### PR TITLE
Component token now includes optional description clause

### DIFF
--- a/plugins/kinparse.py
+++ b/plugins/kinparse.py
@@ -96,7 +96,7 @@ def _parse_netlist_kicad(text):
     sheetpath = Group(_paren_clause('sheetpath', name & tstamp))('sheetpath')
     comp = Group(_paren_clause('comp', ref & value & Optional(datasheet) & 
                     Optional(fields) & Optional(libsource) & Optional(footprint) & 
-                    Optional(sheetpath) & Optional(tstamp) & Optional(properties)))
+                    Optional(sheetpath) & Optional(tstamp) & Optional(properties) & Optional(description)))
     components = _paren_clause('components', ZeroOrMore(comp)('parts'))
 
     # Part library section.


### PR DESCRIPTION
When I tried the plugin on one of my netlist files, it threw an error similar to the one in #3. When I played around with the source code, I noticed that the ``description`` field was declared in the component section, but not included in the ``comp`` declaration.